### PR TITLE
Add from_dict method for creating

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -2,6 +2,12 @@ import collections, operator
 
 class frozendict(collections.Mapping):
 
+    @classmethod
+    def from_dict(cls, d):
+        new = cls()
+        new.__dict.update(d)
+        return new
+
     def __init__(self, *args, **kwargs):
         self.__dict = dict(*args, **kwargs)
         self.__hash = None


### PR DESCRIPTION
So I don't have to convert an initializing dict to a tuple list when the dict's keys aren't strings
