### PR TITLE
Implement FrozenOrderedDict

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -2,6 +2,7 @@ import collections
 import operator
 import functools
 
+
 class frozendict(collections.Mapping):
 
     def __init__(self, *args, **kwargs):
@@ -22,6 +23,39 @@ class frozendict(collections.Mapping):
 
     def __repr__(self):
         return '<frozendict %s>' % repr(self.__dict)
+
+    def __hash__(self):
+        if self.__hash is None:
+            hashes = map(hash, self.items())
+            self.__hash = functools.reduce(operator.xor, hashes, 0)
+
+        return self.__hash
+
+
+class frozenordereddict(collections.Mapping):
+    """
+    It is an immutable wrapper around ordered dictionaries that implements the complete :py:class:`collections.Mapping`
+    interface. It can be used as a drop-in replacement for dictionaries where immutability and ordering are desired.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__dict = collections.OrderedDict(*args, **kwargs)
+        self.__hash = None
+
+    def __getitem__(self, key):
+        return self.__dict[key]
+
+    def copy(self, **add_or_replace):
+        return frozenordereddict(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self.__dict)
+
+    def __len__(self):
+        return len(self.__dict)
+
+    def __repr__(self):
+        return '<frozenordereddict %s>' % repr(self.__dict)
 
     def __hash__(self):
         if self.__hash is None:

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -32,7 +32,7 @@ class frozendict(collections.Mapping):
         return self.__hash
 
 
-class frozenordereddict(collections.Mapping):
+class FrozenOrderedDict(collections.Mapping):
     """
     It is an immutable wrapper around ordered dictionaries that implements the complete :py:class:`collections.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability and ordering are desired.
@@ -46,7 +46,7 @@ class frozenordereddict(collections.Mapping):
         return self.__dict[key]
 
     def copy(self, **add_or_replace):
-        return frozenordereddict(self, **add_or_replace)
+        return FrozenOrderedDict(self, **add_or_replace)
 
     def __iter__(self):
         return iter(self.__dict)
@@ -55,7 +55,7 @@ class frozenordereddict(collections.Mapping):
         return len(self.__dict)
 
     def __repr__(self):
-        return '<frozenordereddict %s>' % repr(self.__dict)
+        return '<FrozenOrderedDict %s>' % repr(self.__dict)
 
     def __hash__(self):
         if self.__hash is None:


### PR DESCRIPTION
# What is this PR?

`frozendict` can be used as a drop-in replacement for dictionaries where immutability is desired, but the traversal order is undefined. `frozenorderdict` is an immutable  dict that remembers the order that keys were first inserted. It wraps the builtin `collections.OrderedDict`.