### PR TITLE
Restore compatibility with python 2.6

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -56,5 +56,5 @@ class FrozenOrderedDict(frozendict):
     dict_cls = OrderedDict
 
 
-if sys.version >= (2, 7):
+if OrderedDict is NotImplemented:
     del FrozenOrderedDict

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -1,6 +1,13 @@
 import collections
 import operator
 import functools
+import sys
+
+
+try:
+    from collections import OrderedDict
+except ImportError:  # python < 2.7
+    OrderedDict = NotImplemented
 
 
 class frozendict(collections.Mapping):
@@ -46,4 +53,8 @@ class FrozenOrderedDict(frozendict):
     A FrozenDict subclass that maintains key order
     """
 
-    dict_cls = collections.OrderedDict
+    dict_cls = OrderedDict
+
+
+if sys.version >= (2, 7):
+    del FrozenOrderedDict

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name     = 'frozendict',
-    version  = '1.0',
+    version  = '1.1',
     url      = 'https://github.com/slezica/python-frozendict',
 
     author       = 'Santiago Lezica',


### PR DESCRIPTION
63895ec09d5e28f4c3a308c737503c61e4e3bb43 accidentally broke python 2.6 compatibility due to usage of OrderedDict, which is not available in the collections module in that version.

Possible fixes were:

1. Skip defining FrozenOrderedDict when running 2.6
2. Depend on ordereddict module when running 2.6 and import it when needed
3. Copy OrderedDict recipe and use it when needed

the last one was chosen due to compatible license, stability of recipe etc.