### PR TITLE
Performance improvements

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -1,6 +1,7 @@
 import collections
-import operator
-import functools
+
+
+iteritems = getattr(dict, 'iteritems', dict.items)
 
 
 class frozendict(collections.Mapping):
@@ -35,9 +36,10 @@ class frozendict(collections.Mapping):
 
     def __hash__(self):
         if self._hash is None:
-            hashes = map(hash, self.items())
-            self._hash = functools.reduce(operator.xor, hashes, 0)
-
+            h = 0
+            for key, value in iteritems(self._dict):
+                h ^= hash((key, value))
+            self._hash = h
         return self._hash
 
 


### PR DESCRIPTION
ping @ppolewicz, @lurch.

This fixes the memory explosion and also uses the best performing method on both CPython 2 and 3, which is to use the `dict.items`/`dict.iteritems` loop. Here are the following implementations I tested:

 - [1]:

    ```
    h = 0
    for key in self:
        h ^= hash((key, self[key]))
    ```
 - [2]:

    ```
    h = 0
    for key, value in iteritems(self._dict):
        h ^= hash((key, value))
    ```

 - [3]:

    ```
    h = functools.reduce(operator.xor, itertools.imap(hash, self.iteritems()), 0)
    ```

Results (total time taken for 10000 operations):


| version   | CPython 2.7.10        | CPython 3.5.2         | PyPy 5.3.1             |
|-----------|-----------------------|-----------------------|------------------------|
| `master`  | `0.13405108451843262` | `0.1642755569992005`  | `0.06007695198059082`  |
| `[1]`     | `0.09088802337646484` | `0.11932992500078399` | `0.025845050811767578` |
| `[2]`     | `0.04392409324645996` | `0.06600762600101007` | `0.018594026565551758` |
| `[3]`     | `0.12008500099182129` | `0.15780412599997362` | `0.04183793067932129`  |

Benchmark code:

```
from timeit import timeit

nested = {
    "login": "octocat",
    "id": 1,
    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
    "gravatar_id": "",
    "url": "https://api.github.com/users/octocat",
    "html_url": "https://github.com/octocat",
    "followers_url": "https://api.github.com/users/octocat/followers",
    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
    "organizations_url": "https://api.github.com/users/octocat/orgs",
    "repos_url": "https://api.github.com/users/octocat/repos",
    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
    "received_events_url": "https://api.github.com/users/octocat/received_events",
    "type": "User",
    "site_admin": False,
    }

t1 = timeit(
    r"hash(frozendict(nested))",
    setup="from v1 import frozendict; from __main__ import nested",
    number=10000,
    )
t2 = timeit(
    r"hash(frozendict(nested))",
    setup="from frozendict import frozendict; from __main__ import nested",
    number=10000,
    )
print('baseline:', t1)
print('improved:', t2)
```