### PR TITLE
Recursive freeze and unfreeze functions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.txt
+include tests.py

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -62,3 +62,37 @@ class FrozenOrderedDict(frozendict):
 
 if OrderedDict is NotImplemented:
     del FrozenOrderedDict
+
+
+def unfreeze(frozen):
+    if type(frozen) is tuple or type(frozen) is list:
+        return list(map(unfreeze, frozen))
+    elif type(frozen) is OrderedDict or type(frozen) is FrozenOrderedDict:
+        writable = OrderedDict()
+        for key in frozen:
+            writable[key] = unfreeze(frozen[key])
+        return writable
+    elif type(frozen) is dict or type(frozen) is frozendict:
+        writable = {}
+        for key in frozen:
+            writable[key] = unfreeze(frozen[key])
+        return writable
+    else:
+        return frozen
+
+
+def freeze(writable):
+    if type(writable) is tuple or type(writable) is list:
+        return tuple(map(freeze, writable))
+    elif type(writable) is OrderedDict or type(writable) is FrozenOrderedDict:
+        frozen = OrderedDict()
+        for key in writable:
+            frozen[key] = freeze(writable[key])
+        return FrozenOrderedDict(frozen)
+    elif type(writable) is dict or type(writable) is frozendict:
+        frozen = {}
+        for key in writable:
+            frozen[key] = freeze(writable[key])
+        return frozendict(frozen)
+    else:
+        return writable

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -66,33 +66,21 @@ if OrderedDict is NotImplemented:
 
 def unfreeze(frozen):
     if type(frozen) is tuple or type(frozen) is list:
-        return list(map(unfreeze, frozen))
+        return list(unfreeze(x) for x in frozen)
     elif type(frozen) is OrderedDict or type(frozen) is FrozenOrderedDict:
-        writable = OrderedDict()
-        for key in frozen:
-            writable[key] = unfreeze(frozen[key])
-        return writable
+        return OrderedDict([(k, unfreeze(v)) for k, v in frozen.items()])
     elif type(frozen) is dict or type(frozen) is frozendict:
-        writable = {}
-        for key in frozen:
-            writable[key] = unfreeze(frozen[key])
-        return writable
+        return {k: unfreeze(v) for k, v in frozen.items()}
     else:
         return frozen
 
 
 def freeze(writable):
     if type(writable) is tuple or type(writable) is list:
-        return tuple(map(freeze, writable))
+        return tuple(freeze(x) for x in writable)
     elif type(writable) is OrderedDict or type(writable) is FrozenOrderedDict:
-        frozen = OrderedDict()
-        for key in writable:
-            frozen[key] = freeze(writable[key])
-        return FrozenOrderedDict(frozen)
+        return FrozenOrderedDict([(k, freeze(v)) for k, v in writable.items()])
     elif type(writable) is dict or type(writable) is frozendict:
-        frozen = {}
-        for key in writable:
-            frozen[key] = freeze(writable[key])
-        return frozendict(frozen)
+        return {k: freeze(v) for k, v in writable.items()}
     else:
         return writable

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -81,6 +81,6 @@ def freeze(writable):
     elif type(writable) is OrderedDict or type(writable) is FrozenOrderedDict:
         return FrozenOrderedDict([(k, freeze(v)) for k, v in writable.items()])
     elif type(writable) is dict or type(writable) is frozendict:
-        return {k: freeze(v) for k, v in writable.items()}
+        return frozendict({k: freeze(v) for k, v in writable.items()})
     else:
         return writable

--- a/frozendict/tests.py
+++ b/frozendict/tests.py
@@ -133,18 +133,28 @@ class TestFrozenOrderedDict(BaseTestCase):
 
 class TestFreezeAndUnfreeze(BaseTestCase):
     def test_freeze_dict(self):
-        self.assertEqual(freeze({}), frozendict({}))
-    def test_freeze_dict(self):
-        self.assertEqual(freeze({'a': 1}), frozendict({'a': 1}))
+        writable = {}
+        expected = frozendict(writable)
+        result = freeze(writable)
+        self.assertIs(type(result), type(expected))
+        self.assertEqual(freeze(writable), expected)
+    def test_freeze_dict2(self):
+        writable = {'a': 1}
+        expected = frozendict(writable)
+        result = freeze(writable)
+        self.assertIs(type(result), type(expected))
+        self.assertEqual(freeze(writable), expected)
     def test_freeze_ordered(self):
         writable = OrderedDict({})
         expected = FrozenOrderedDict({})
+        result = freeze(writable)
+        self.assertIs(type(result), type(expected))
         self.assertEqual(freeze(writable), expected)
     def test_freeze_ordered2(self):
         writable = OrderedDict({'a':1})
         expected = FrozenOrderedDict({'a': 1})
         result = freeze(writable)
-        self.assertIs(type(result), FrozenOrderedDict)
+        self.assertIs(type(result), type(expected))
         self.assertEqual(result, expected)
     def test_freeze_list(self):
         self.assertEqual(freeze([1,2,3]), (1,2,3))

--- a/frozendict/tests.py
+++ b/frozendict/tests.py
@@ -160,15 +160,15 @@ class TestFreezeAndUnfreeze(BaseTestCase):
         expected = frozendict({
             'a': (1,2, frozendict(({'a': 1}))),
             'b': 'foo',
-            'c': {
+            'c': frozendict({
                 'd': frozendict({})
-            },
+            }),
             'e': {'f': FrozenOrderedDict({'a':1})}
         })
         self.assertEqual(freeze(writable), expected)
-        self.assertEqual(unfreeze(expected), writable)
+        self.assertDictEqual(unfreeze(expected), writable)
         ordered = unfreeze(expected)['e']['f']
         self.assertIs(type(ordered), OrderedDict)
-        self.assertEqual(unfreeze(freeze(writable)), writable)
+        self.assertDictEqual(unfreeze(freeze(writable)), writable)
         self.assertEqual(freeze(expected), expected)
 

--- a/frozendict/tests.py
+++ b/frozendict/tests.py
@@ -1,0 +1,131 @@
+from unittest import TestCase
+
+from frozendict import frozendict, FrozenOrderedDict
+
+
+class BaseTestCase(TestCase):
+    def assertMappingEqual(self, m1, m2):
+        # `assertDictEqual` will make a failing type check when comparing a `dict`
+        # with a `frozendict`. Instead, we'll compare the item sets:
+        self.assertSetEqual(set(m1.items()), set(m2.items()))
+
+    def assertRaisesAssignmentError(self, *args, **kwargs):
+        self.assertRaisesRegexp(
+            TypeError,
+            r'object does not support item assignment',
+            *args, **kwargs
+        )
+
+
+def setitem(dct, key, value):
+    dct[key] = value
+
+
+class TestFrozenDict(BaseTestCase):
+    def test_assignment_fails(self):
+        self.assertRaisesAssignmentError(setitem, frozendict(), 'key', 'value')
+
+    def test_init(self):
+        frozendict()
+
+    def test_init_with_keys(self):
+        fd = frozendict(a=0, b=1)
+        self.assertMappingEqual(fd, dict(a=0, b=1))
+
+    def test_init_with_dict(self):
+        fd = frozendict(dict(a=0, b=1))
+        self.assertMappingEqual(fd, dict(a=0, b=1))
+
+    def test_init_with_dict_and_keys(self):
+        fd = frozendict(dict(a=0, b=1), b=2, c=3)
+        self.assertMappingEqual(fd, dict(a=0, b=2, c=3))
+
+    def test_getitem(self):
+        fd = frozendict(key='value')
+        self.assertEqual(fd['key'], 'value')
+
+    def test_copy(self):
+        fd = frozendict(a=0, b=1)
+        copied = fd.copy()
+        self.assertIs(type(copied), type(fd))
+        self.assertMappingEqual(copied, fd)
+
+    def test_copy_with_keys(self):
+        fd = frozendict(a=0, b=1)
+        copied = fd.copy(b=2, c=3)
+        self.assertIs(type(copied), type(fd))
+        self.assertMappingEqual(copied, dict(a=0, b=2, c=3))
+
+    def test_iter(self):
+        fd = frozendict(a=0, b=1)
+        keys = {key for key in fd}
+        self.assertSetEqual(keys, {'a', 'b'})
+
+    def test_len(self):
+        fd = frozendict(a=0, b=1)
+        self.assertEqual(len(fd), 2)
+
+    def test_repr(self):
+        fd = frozendict(a=0, b=1)
+        r = repr(fd)
+        self.assertTrue(r.startswith('<frozendict '))
+        self.assertTrue(r.endswith('>'))
+
+    def test_hash(self):
+        fd = frozendict(a=0, b=1)
+        hash(fd)
+
+
+class TestFrozenOrderedDict(BaseTestCase):
+    def test_assignment_fails(self):
+        self.assertRaisesAssignmentError(setitem, FrozenOrderedDict(), 'key', 'value')
+
+    def test_init(self):
+        FrozenOrderedDict()
+
+    def test_init_with_keys(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        self.assertMappingEqual(fd, dict(a=0, b=1))
+
+    def test_init_with_dict(self):
+        fd = FrozenOrderedDict(dict(a=0, b=1))
+        self.assertMappingEqual(fd, dict(a=0, b=1))
+
+    def test_init_with_dict_and_keys(self):
+        fd = FrozenOrderedDict(dict(a=0, b=1), b=2, c=3)
+        self.assertMappingEqual(fd, dict(a=0, b=2, c=3))
+
+    def test_getitem(self):
+        fd = FrozenOrderedDict(key='value')
+        self.assertEqual(fd['key'], 'value')
+
+    def test_copy(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        copied = fd.copy()
+        self.assertIs(type(copied), type(fd))
+        self.assertMappingEqual(copied, fd)
+
+    def test_copy_with_keys(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        copied = fd.copy(b=2, c=3)
+        self.assertIs(type(copied), type(fd))
+        self.assertMappingEqual(copied, dict(a=0, b=2, c=3))
+
+    def test_iter(self):
+        fd = FrozenOrderedDict([('a', 0), ('c', 2), ('b', 1), ('d', 3)])
+        keys = [key for key in fd]
+        self.assertListEqual(keys, ['a', 'c', 'b', 'd']) # verifies order
+
+    def test_len(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        self.assertEqual(len(fd), 2)
+
+    def test_repr(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        r = repr(fd)
+        self.assertTrue(r.startswith('<FrozenOrderedDict '))
+        self.assertTrue(r.endswith('>'))
+
+    def test_hash(self):
+        fd = FrozenOrderedDict(a=0, b=1)
+        hash(fd)

--- a/frozendict/tests.py
+++ b/frozendict/tests.py
@@ -165,10 +165,17 @@ class TestFreezeAndUnfreeze(BaseTestCase):
             }),
             'e': {'f': FrozenOrderedDict({'a':1})}
         })
-        self.assertEqual(freeze(writable), expected)
+        frozen = freeze(writable)
+        def modify(d, k):
+            d[k] = None
+        for k in expected:
+            self.assertRaises(TypeError, modify, expected, k)
+        for k in frozen:
+            self.assertRaises(TypeError, modify, frozen, k)
+        self.assertEqual(frozen, expected)
         self.assertDictEqual(unfreeze(expected), writable)
         ordered = unfreeze(expected)['e']['f']
         self.assertIs(type(ordered), OrderedDict)
-        self.assertDictEqual(unfreeze(freeze(writable)), writable)
+        self.assertDictEqual(unfreeze(frozen), writable)
         self.assertEqual(freeze(expected), expected)
 

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,7 @@ setup(
     license  = 'MIT License',
 
     description      = 'An immutable dictionary',
-    long_description = open('README.rst').read()
+    long_description = open('README.rst').read(),
+
+    test_suite = 'tests',
 )


### PR DESCRIPTION
Theses are two symmetrical functions to make entire structures immutable and mutable respectively. Converting `dict` and `OrderedDict` will behave as expected. All lists are turned into tuples and vice versa.

I have based on #15 to integrate with the testing. If this is of interest I will consider adding [hypothesis](https://hypothesis.readthedocs.io/en/latest/) tests to show that `freeze(unfreeze(x)) == x` and `unfreeze(freeze(x)) == x` hold true given completely frozen or unfrozen data structures respectively. 