### PR TITLE
Reuse frozendict passed to constructor.

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -21,6 +21,11 @@ class frozendict(collections.Mapping):
 
     dict_cls = dict
 
+    def __new__(cls, *args, **kwargs):
+        if args and not kwargs and type(args[0]) == cls and cls in (frozendict, FrozenOrderedDict):
+            return args[0]
+        return super(frozendict, cls).__new__(cls)
+
     def __init__(self, *args, **kwargs):
         self._dict = self.dict_cls(*args, **kwargs)
         self._hash = None


### PR DESCRIPTION
When you pass a `frozenset` as the argument to the `frozenset` class you get back the same object you passed in:

```python
>>> s = frozenset({1, 2, 3})
>>> s is frozenset(s)
True
```

This is a nice property, since it allows you to easily coerce any iterable into a `frozenset` without needing to clone and keep the same immutable information in memory if it's already a `frozenset`.

This PR updates the `frozendict` class to work similarly:
```python
>>> import frozendict
>>> f = frozendict.frozendict({'one': 1, 'two': 2})
>>> f is frozendict.frozendict(f)
True
```

When a `frozendict` is passed to the `frozendict` class as the only argument, that `frozendict` is returned instead of creating a new one.

I ensure here that the types need to match exactly (no `isinstance`) to allow coercing into a different subclass:
```python
>>> import frozendict
>>> f = frozendict.FrozenOrderedDict({'one': 1, 'two': 2})
>>> f is frozendict.frozendict(f)
True
```

I also force this property to only hold for the classes defined in this module: `frozendict` and `FrozenOrderedDict`. The reason for this is I worry about subclasses who decide to have mutable properties (for whatever reason), or who define their own `__init__`:

```python
>>> # !!! WITHOUT THE EXPLICIT CLASS CHECK !!!
>>> import frozendict
>>>
>>>
>>> class Bad(frozendict.frozendict):
...     def __init__(self, one, two):
...         super().__init__({**one, **two})
...
>>>
>>> b = Bad({'one': 1}, {'two': 2})
>>>
>>> b is not Bad(b, {'three': 3})
False
```
