### PR TITLE
Fix warnings from collections

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -9,11 +9,16 @@ try:
 except ImportError:  # python < 2.7
     OrderedDict = NotImplemented
 
+try:
+    from collections.abc import Mapping
+except ImportError:  # python < 3.3
+    from collections import Mapping
+
 
 iteritems = getattr(dict, 'iteritems', dict.items) # py2-3 compatibility
 
 
-class frozendict(collections.Mapping):
+class frozendict(Mapping):
     """
     An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.


### PR DESCRIPTION
Specifically, the following DeprecationWarning due to changes in Python
3.7 [1]
```
/home/yen/Projects/python-frozendict/frozendict/__init__.py:16: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class frozendict(collections.Mapping):
```

Tested with:
```
$ PYTHONWARNINGS=all python3 -c 'from frozendict import frozendict'
$ PYTHONWARNINGS=all python2 -c 'from frozendict import frozendict'
```

[1] https://github.com/python/cpython/pull/5460