### PR TITLE
Add Python 3 specifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,17 @@ Example shell usage:
 
 .. code-block:: python
 
+    from __future__ import print_function
+
     from frozendict import frozendict
 
     fd = frozendict({ 'hello': 'World' })
 
-    print fd
+    print(fd)
     # <frozendict {'hello': 'World'}>
 
-    print fd['hello']
+    print(fd['hello'])
     # 'World'
 
-    print fd.copy(another='key/value')
+    print(fd.copy(another='key/value'))
     # <frozendict {'hello': 'World', 'another': 'key/value'}>

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -1,7 +1,4 @@
 import collections
-import operator
-import functools
-import sys
 
 
 try:
@@ -10,7 +7,7 @@ except ImportError:  # python < 2.7
     OrderedDict = NotImplemented
 
 
-iteritems = getattr(dict, 'iteritems', dict.items) # py2-3 compatibility
+iteritems = getattr(dict, "iteritems", dict.items)  # py2-3 compatibility
 
 
 class frozendict(collections.Mapping):
@@ -41,7 +38,7 @@ class frozendict(collections.Mapping):
         return len(self._dict)
 
     def __repr__(self):
-        return '<%s %r>' % (self.__class__.__name__, self._dict)
+        return "<%s %r>" % (self.__class__.__name__, self._dict)
 
     def __hash__(self):
         if self._hash is None:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 from setuptools import setup
 
+with open("README.rst") as readme_file:
+    LONG_DESCRIPTION = readme_file.read()
+
 setup(
     name     = 'frozendict',
-    version  = '1.2',
+    version  = '1.3',
     url      = 'https://github.com/slezica/python-frozendict',
 
     author       = 'Santiago Lezica',
@@ -12,5 +15,10 @@ setup(
     license  = 'MIT License',
 
     description      = 'An immutable dictionary',
-    long_description = open('README.rst').read()
+    long_description=LONG_DESCRIPTION,
+
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+    ],
 )


### PR DESCRIPTION
Make sure to close the README file in setup.py
Remove useless imports
Use the Black formatter on __init__.py
Adapt the example code for Python 2 and 3 compatibility