### PR TITLE
Add to classifiers supported python versions (2, 2.7, 3, 3.4 -- 3.8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     packages = ['frozendict'],

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,15 @@ setup(
     author       = 'Santiago Lezica',
     author_email = 'slezica89@gmail.com',
 
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+    ],
+
     packages = ['frozendict'],
     license  = 'MIT License',
 


### PR DESCRIPTION
It will help those people who will do some version compatability checking with officially recomended tool **caniusepython3** which looks exactly into classifiers to detect that an examined lib supports Python 3.

As I can see this lib already supports Python 2.7 and some versions of Python 3.

It was tested on Python 3.4. Seems like all is fine. So I've specified those two versions as a first step.

I think it might especially helpful for those who realized that Python 2 EOL is coming :-)

