### PR TITLE
Fix collections.abc imports for Python 3.9

### DIFF
--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -4,9 +4,9 @@ import sys
 
 try:
     # Python 3.3+
-    from collections import Mapping
-except ImportError:
     from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 try:
     from collections import OrderedDict

--- a/frozendict/__init__.py
+++ b/frozendict/__init__.py
@@ -1,8 +1,12 @@
-import collections
 import operator
 import functools
 import sys
 
+try:
+    # Python 3.3+
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 
 try:
     from collections import OrderedDict
@@ -13,9 +17,9 @@ except ImportError:  # python < 2.7
 iteritems = getattr(dict, 'iteritems', dict.items) # py2-3 compatibility
 
 
-class frozendict(collections.Mapping):
+class frozendict(Mapping):
     """
-    An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
+    An immutable wrapper around dictionaries that implements the complete :py:class:`collections.abc.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.
     """
 


### PR DESCRIPTION
Fixes https://github.com/slezica/python-frozendict/issues/25.

From Python 3.9, `Mapping` is only available in `collections.abc`.

```pycon
Python 3.9.0a2+ (heads/master:ec007cb, Jan  5 2020, 12:34:22)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Mapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Mapping' from 'collections' (/Users/hugo/.pyenv/versions/3.9-dev/lib/python3.9/collections/__init__.py)
>>> from collections.abc import Mapping
>>> 
```

This Fedora bug report shows it's affecting other libraries that depend upon frozendict: https://bugzilla.redhat.com/show_bug.cgi?id=1792039

Python 3.9 is in alpha, with a full release due for October 2020.

* https://www.python.org/dev/peps/pep-0596/

Thanks!